### PR TITLE
Ensure the opened config file gets closed and that an HTTP(S) connection is made before RPC call

### DIFF
--- a/python/bitcoind.py
+++ b/python/bitcoind.py
@@ -194,6 +194,7 @@ class Bitcoind(object):
         self._rpc_id += 1
 
         logger.debug('Starting "%s" JSON-RPC request', method)
+        self._rpc_conn.connect()
         self._rpc_conn.request(
             method='POST',
             url='/',

--- a/python/bitcoind.py
+++ b/python/bitcoind.py
@@ -128,6 +128,8 @@ class Bitcoind(object):
 
                         config[var] = val
 
+                    conf.close()
+
             except Exception as e:
                 logger.error('%s reading %s: %s', type(e).__name__, filename, str(e))
 


### PR DESCRIPTION
**Issue 1**
The _parse_config() function in bitcoind.py opens a file object but never closes it. If another program using pifkoin instantiates Bitcoind enough times, the system will eventually throw a "too many files open" error due to the constant opening without closing of files by pifkoin.

**Issue 2**
Making requests to the established HTTP(S)Connection several seconds apart (in this case, 60 seconds) causes BadStatusLine to be thrown because the connection is no longer established. Python documentation states that .connect() is called by default before every request, but this does not seem to be the case. Explicitly calling self._rpc_conn.connect() before the request in _rpc_call() resolves the issue.